### PR TITLE
Example Android App Explicit Theme

### DIFF
--- a/RNZoomUSBridgeExample/android/app/build.gradle
+++ b/RNZoomUSBridgeExample/android/app/build.gradle
@@ -182,6 +182,7 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation 'com.google.android.material:material:+'
 
     if (enableHermes) {
         def hermesPath = "../../node_modules/hermes-engine/android/";


### PR DESCRIPTION
## Changes
1. Added explicit reference to app theme.

## Purpose
Fixes `error: resource style/Theme.MaterialComponents.DayNight (aka com.rnzoomusbridgeexample:style/Theme.MaterialComponents.DayNight) not found.` error in the android build process.

## Approach
Mostly just a carbon copy of https://stackoverflow.com/questions/53186009/error-compiling-android-app-with-material-components-and-androidx but also making sure we always get the newest version that comes packaged within the app.

Closes #34 